### PR TITLE
Upkeep

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -4,10 +4,10 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
-  workflow_dispatch:
 
-name: R-CMD-check
+name: R-CMD-check.yaml
+
+permissions: read-all
 
 jobs:
   R-CMD-check:
@@ -30,7 +30,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -42,10 +42,10 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          cache-version: 3
           extra-packages: any::rcmdcheck
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -4,12 +4,13 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
   release:
     types: [published]
   workflow_dispatch:
 
-name: pkgdown
+name: pkgdown.yaml
+
+permissions: read-all
 
 jobs:
   pkgdown:
@@ -22,7 +23,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -41,7 +42,7 @@ jobs:
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
         with:
           clean: false
           branch: gh-pages

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nflverse
 Title: Easily Install and Load the 'nflverse'
-Version: 1.0.3
+Version: 1.0.3.9000
 Authors@R: c(
     person("Sebastian", "Carl", , "mrcaseb@gmail.com", role = c("aut", "cre")),
     person("Ben", "Baldwin", , "bbaldwin206@gmail.com", role = "aut"),
@@ -17,15 +17,17 @@ Description: The 'nflverse' is a set of packages dedicated to data of the
 License: MIT + file LICENSE
 URL: https://nflverse.nflverse.com/, https://github.com/nflverse/nflverse
 BugReports: https://github.com/nflverse/nflverse/issues
+Depends: 
+    R (>= 4.1.0)
 Imports: 
     cli (>= 3.0.0),
     crayon (>= 1.4.0),
     magrittr (>= 2.0.0),
-    nfl4th (>= 1.0.3),
-    nflfastR (>= 4.5.1),
-    nflplotR (>= 1.1.0),
-    nflreadr (>= 1.3.2),
-    nflseedR (>= 1.2.0),
+    nfl4th (>= 1.0.4),
+    nflfastR (>= 5.0.0),
+    nflplotR (>= 1.4.0),
+    nflreadr (>= 1.4.1),
+    nflseedR (>= 2.0.0),
     rlang (>= 0.4.10),
     rstudioapi (>= 0.13)
 Suggests: 
@@ -33,4 +35,4 @@ Suggests:
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# nflverse (development version)
+
+* Update required nflverse package versions. (#22)
+* nflverse now requires R 4.1 to allow the package to use R's native pipe `|>` operator. This follows the [Tidyverse R version support rules](https://www.tidyverse.org/blog/2019/04/r-version-support/). (#22)
+
 # nflverse 1.0.3
 
 * Minor changes - requested by CRAN - related to nfl4th.

--- a/R/conflicts.R
+++ b/R/conflicts.R
@@ -25,14 +25,14 @@
 #     right = "nflverse_conflicts()"
 #   )
 #
-#   pkgs <- x %>% purrr::map(~ gsub("^package:", "", .))
-#   others <- pkgs %>% purrr::map(`[`, -1)
+#   pkgs <- x |> purrr::map(~ gsub("^package:", "", .))
+#   others <- pkgs |> purrr::map(`[`, -1)
 #   other_calls <- purrr::map2_chr(
 #     others, names(others),
 #     ~ paste0(crayon::blue(.x), "::", .y, "()", collapse = ", ")
 #   )
 #
-#   winner <- pkgs %>% purrr::map_chr(1)
+#   winner <- pkgs |> purrr::map_chr(1)
 #   funs <- format(paste0(
 #     crayon::blue(winner),
 #     "::",
@@ -55,8 +55,8 @@
 #
 # confirm_conflict <- function(packages, name) {
 #   # Only look at functions
-#   objs <- packages %>%
-#     purrr::map(~ get(name, pos = .)) %>%
+#   objs <- packages |>
+#     purrr::map(~ get(name, pos = .)) |>
 #     purrr::keep(is.function)
 #
 #   if (length(objs) <= 1) {

--- a/R/nflverse-package.R
+++ b/R/nflverse-package.R
@@ -5,7 +5,6 @@
 # The following block is used by usethis to automatically manage
 # roxygen namespace tags. Modify with care!
 ## usethis namespace: start
-#' @importFrom magrittr %>%
 #' @importFrom nfl4th load_4th_pbp
 #' @importFrom nflfastR calculate_expected_points
 #' @importFrom nflplotR valid_team_names

--- a/R/updates_and_reports.R
+++ b/R/updates_and_reports.R
@@ -68,9 +68,9 @@ nflverse_update <- function(recursive = FALSE,
   packages <- nflverse_packages(include_self = TRUE)
 
   if(isTRUE(recursive)){
-    deps <- tools::package_dependencies(packages, db = available) %>%
-      unlist() %>%
-      unique() %>%
+    deps <- tools::package_dependencies(packages, db = available) |>
+      unlist() |>
+      unique() |>
       sort()
     base_pkgs <- c(
       "base", "compiler", "datasets", "graphics", "grDevices", "grid",
@@ -82,8 +82,8 @@ nflverse_update <- function(recursive = FALSE,
     packages <- sort(c(packages, deps))
   }
 
-  cran_version <- available[packages, "Version"] %>%
-    base::package_version() %>%
+  cran_version <- available[packages, "Version"] |>
+    base::package_version() |>
     as.character()
   local_version <- vapply(packages, packageVersion, character(1L))
   behind <- cran_version > local_version

--- a/README.Rmd
+++ b/README.Rmd
@@ -19,7 +19,7 @@ knitr::opts_chunk$set(
 <!-- badges: start -->
 [![CRAN status](https://img.shields.io/cran/v/nflverse?style=flat-square&logo=R&label=CRAN)](https://CRAN.R-project.org/package=nflverse)
 [![Dev status](https://img.shields.io/github/r-package/v/nflverse/nflverse/main?label=dev%20version&style=flat-square&logo=github)](https://nflverse.nflverse.com/)
-[![R-CMD-check](https://github.com/nflverse/nflverse/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/nflverse/nflverse/actions/workflows/R-CMD-check.yaml)
+[![R-CMD-check](https://img.shields.io/github/actions/workflow/status/nflverse/nflverse/R-CMD-check.yaml?label=R%20check&style=flat-square&logo=github)](https://github.com/nflverse/nflverse/actions/workflows/R-CMD-check.yaml)
 [![nflverse support](https://img.shields.io/discord/789805604076126219?color=7289da&label=nflverse%20support&logo=discord&logoColor=fff&style=flat-square)](https://discord.com/invite/5Er2FBnnQa)
 <!-- badges: end -->
 
@@ -38,7 +38,7 @@ install.packages("nflverse")
 To get a bug fix or to use a feature from the development version, you can install the development version of nflverse either from [GitHub](https://github.com/nflverse/nflverse/) with:
 
 ```{r eval = FALSE}
-if (!require("pak")) install.packages("pak")
+if (!requireNamespace("pak")) install.packages("pak")
 pak::pak("nflverse/nflverse")
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 status](https://img.shields.io/cran/v/nflverse?style=flat-square&logo=R&label=CRAN)](https://CRAN.R-project.org/package=nflverse)
 [![Dev
 status](https://img.shields.io/github/r-package/v/nflverse/nflverse/main?label=dev%20version&style=flat-square&logo=github)](https://nflverse.nflverse.com/)
-[![R-CMD-check](https://github.com/nflverse/nflverse/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/nflverse/nflverse/actions/workflows/R-CMD-check.yaml)
+[![R-CMD-check](https://img.shields.io/github/actions/workflow/status/nflverse/nflverse/R-CMD-check.yaml?label=R%20check&style=flat-square&logo=github)](https://github.com/nflverse/nflverse/actions/workflows/R-CMD-check.yaml)
 [![nflverse
 support](https://img.shields.io/discord/789805604076126219?color=7289da&label=nflverse%20support&logo=discord&logoColor=fff&style=flat-square)](https://discord.com/invite/5Er2FBnnQa)
 <!-- badges: end -->
@@ -52,8 +52,7 @@ install.packages("nflverse", repos = c("https://nflverse.r-universe.dev", getOpt
 
 `library(nflverse)` will load the following nflverse packages:
 
-- [nflfastR](https://www.nflfastr.com/), for play-by-play data back to
-  1999.
+- [nflfastR](https://www.nflfastr.com/), for play-by-play data back to 1999.
 - [nflseedR](https://nflseedr.com/), for season simulations.
 - [nfl4th](https://www.nfl4th.com/), for 4th down analysis.
 - [nflreadr](https://nflreadr.nflverse.com/), for fast end efficient

--- a/nflverse.Rproj
+++ b/nflverse.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: ad1e83b9-175d-45c0-b5b3-c958e4fe5592
 
 RestoreWorkspace: No
 SaveWorkspace: No

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -2,15 +2,15 @@ url: https://nflverse.nflverse.com
 
 authors:
   Sebastian Carl:
-    href: https://twitter.com/mrcaseb
+    href: https://bsky.app/profile/mrcaseb.nflverse.com
   Ben Baldwin:
-    href: https://twitter.com/benbbaldwin
+    href: https://bsky.app/profile/rbsdm.com
   Lee Sharpe:
     href: https://twitter.com/LeeSharpeNFL
   Tan Ho:
-    href: https://twitter.com/_TanHo
+    href: https://tanho.ca
   John Edwards:
-    href: https://twitter.com/John_B_Edwards
+    href: https://johnbedwards.io
 
 home:
   title: nflverse • Data and Tools for NFL Analytics
@@ -22,7 +22,7 @@ navbar:
   bg: dark
   structure:
     left:  [home, intro, reference, news, articles]
-    right: [discord, github, more]
+    right: [search, discord, github, more]
   components:
     discord:
       icon: "fab fa-discord fa-lg"
@@ -58,7 +58,6 @@ navbar:
 template:
   bootstrap: 5
   bootswatch: cosmo
-  # theme: arrow-light
   bslib:
     font_scale: 1.2
     base_font: {google: "IBM Plex Sans"}


### PR DESCRIPTION
- bumps required nflverse package versions
- requires R4.1 and uses base pipe internally
- magrittr pipe remains in deps and exports as users might rely on the package to load the magrittr pipe
- updates some workflows and pkgdown